### PR TITLE
return bucket_policy after testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,6 @@ Default:
 ```
 
 ### bucket_policy
-> **WARNING**: Do not use for now, further investigation needed.
-
 Additional bucket policy statements.
 Default policy allows only SSL requests.
 ```json
@@ -134,16 +132,10 @@ module "aws_s3" {
   }],
   "bucket_policy": [
     {
-      "Sid" : "test_allow",
-      "Effect" : "Allow",
-      "Principal" : "*",
-      "Action" : "s3:*"
-    },
-    {
-      "Sid" : "test_deny",
-      "Effect" : "Deny",
-      "Principal" : "*",
-      "Action" : "s3:GetObject"
+      "Sid": "testpolicy",
+      "Effect": "Allow",
+      "Principal": {"Service": "cloudtrail.amazonaws.com"},
+      "Action": "s3:GetBucketAcl"
     }
   ]
 }

--- a/main.tf
+++ b/main.tf
@@ -1,13 +1,11 @@
 locals {
   # Adding resource ARN to custom policies
-  # TODO: check IAM and policy update permissions, got access denied even with admin permission and via console
-  policy = []
-  # policy = [
-  #   for i in var.bucket_policy: merge(i,  {"Resource" = [
-  #         format("arn:aws:s3:::%s", aws_s3_bucket.bucket.id),
-  #         format("arn:aws:s3:::%s/*", aws_s3_bucket.bucket.id)
-  #       ]})
-  #   ]
+  policy = [
+    for i in var.bucket_policy: merge(i,  {"Resource" = [
+          format("arn:aws:s3:::%s", aws_s3_bucket.bucket.id),
+          format("arn:aws:s3:::%s/*", aws_s3_bucket.bucket.id)
+        ]})
+    ]
 }
 
 resource "aws_s3_bucket" "bucket" {

--- a/variables.tf
+++ b/variables.tf
@@ -16,7 +16,7 @@ variable "force_destroy" {
 }
 
 variable "bucket_policy" {
-  type        = list(any)
+  type        = any
   description = "Additional bucket policy statements."
   default     = []
 }


### PR DESCRIPTION
# Description

Returned option for specifyin additional bucket policy as it's needed for [EAGER-752](https://drivevariant.atlassian.net/browse/EAGER-752).
Also updated variable type because otherwise it requires same structure for elements of policy and some might have `condition` while others don't.

Fixes [#752](https://drivevariant.atlassian.net/browse/EAGER-752)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

```text
Manual testing, created bucket before changes and then added changes to module and ran apply again to verify it doesn't break something.
```

- [ ] Sanity Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added documentation to test
