### PR TITLE
add support for tags

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 0
 
       - name: Lint Code Base
-        uses: github/super-linter@v3
+        uses: github/super-linter@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VALIDATE_ALL_CODEBASE: true
+          VALIDATE_ALL_CODEBASE: false

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,3 +20,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_ALL_CODEBASE: false
+          VALIDATE_GITHUB_ACTIONS: false

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
   - [Input Variables](#input-variables)
   - [Variable definitions](#variable-definitions)
     - [bucket_prefix](#bucket_prefix)
+    - [tags](#tags)
     - [force_destroy](#force_destroy)
     - [lifecycle_rule](#lifecycle_rule)
     - [bucket_policy](#bucket_policy)
@@ -19,6 +20,7 @@
 | Name       | Type      | Default     | Example         | Notes     |
 | ---------- | --------- | ------------| --------------- | --------- |
 | bucket_prefix | string | N/A | test-bucket- | Creates a unique bucket name |
+| tags | map(string) | {} | {"environment": "prod"} | |
 | force_destroy | bool | `false` | `true` | |
 | lifecycle_rule | list(object) | [] | `see below` | |
 | bucket_policy | list(any) | [] | `see below` | additional bucket policy statement |
@@ -28,6 +30,17 @@
 Prefix for bucket name, AWS will append it with creation time and serial number.
 ```json
 "bucket_prefix": "<bucket prefix>"
+```
+
+### tags
+Tags for created bucket.
+```json
+"tags": {<map of tag keys and values>}
+```
+
+Default:
+```json
+"tags": {}
 ```
 
 ### force_destroy
@@ -101,6 +114,7 @@ module "aws_s3" {
   source = "github.com/variant-inc/terraform-aws-s3?ref=v1"
 
   bucket_prefix   = var.bucket_prefix
+  tags            = var.tags
   force_destroy   = var.force_destroy
   bucket_policy   = var.bucket_policy
   lifecycle_rule  = var.lifecycle_rule
@@ -111,6 +125,9 @@ module "aws_s3" {
 ```json
 {
   "bucket_prefix":"test-bucket-",
+  "tags": {
+    "environment": "prod"
+  },
   "force_destroy": false,
   "lifecycle_rule": [{
     "prefix": "staged/",

--- a/main.tf
+++ b/main.tf
@@ -12,6 +12,7 @@ resource "aws_s3_bucket" "bucket" {
   #ts:skip=AWS.S3Bucket.LM.MEDIUM.0078 need to skip this rule
 
   bucket_prefix = var.bucket_prefix
+  tags          = var.tags
   acl           = "private"
 
   lifecycle {

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,12 @@ variable "bucket_prefix" {
   description = "Prefix of the s3 bucket"
 }
 
+variable "tags" {
+  type        = map(string)
+  description = "Tags for S3 bucket"
+  default     = {}
+}
+
 variable "lifecycle_rule" {
   type        = list(any)
   description = "A configuration of object lifecycle management"


### PR DESCRIPTION
# Description

Added tags in s3_bucket resource and tags variable with default value of `{}`
Motivation is that we use one terraform code to invoke multiple modules that can create multiple buckets and other resources and by specifying default_tags only on provider level all resources end up with same tags.
This way we'll be able to invoke [tags module](https://github.com/variant-inc/lazy-terraform/tree/master/submodules/tags) multiple times, once for each specific set of tags and use it's output in s3 module invocation.
i.e. creation of bronze and silver buckets for same data pipeline, they should have some things configured differently

Mandatory for [#895](https://drivevariant.atlassian.net/browse/EAGER-895)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested deployment of s3 bucket without specifying any tags.
- bucket gets created without tags
Tested deployment of s3 bucket with specifying tags on provider level.
- verified that tags from provider get pushed to s3 bucket
Tested deployment of s3 bucket with specifying tags on provider level and using output of `tags` module in main.tf
```terraform
module "aws_s3" {
  source = "../../modules/terraform-aws-s3"

  bucket_prefix   = var.bucket_prefix
  tags                 = module.tags.tags
}

module "tags" {
  source = "github.com/variant-inc/lazy-terraform//submodules/tags?ref=v1"

  user_tags = {
    team    = "dataops"
    purpose = "s3 tags test"
    owner   = "Luka"
  }
  octopus_tags = {
    project         = "data-cron-pipelines"
    space           = "DataOps"
    environment     = "playground"
    project_group   = "Default Project Group"
    release_channel = "feature"
  }

  name = "test-s3-bucket"
}
```
- verified that default_tags from provider with same key get overridden by values from `tags` module

- [ ] Sanity Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added documentation to test
