### PR TITLE
bump aws provider version

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | <4.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.22 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | <4.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.22 |
 
 ## Modules
 

--- a/version.tf
+++ b/version.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "<4.0.0"
+      version = "~> 4.22"
     }
   }
 }


### PR DESCRIPTION
# Description

Bumping version of aws provider for s3 bucket module.
https://drivevariant.atlassian.net/browse/CLOUD-1762

TVA PR: https://github.com/variant-inc/terraform-variant-apps/pull/112